### PR TITLE
Add gitpod config

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,43 @@
+FROM gitpod/workspace-full
+
+USER root
+
+ENV GO_VERSION=1.14
+RUN rm -rf /home/gitpod/go && \
+    rm -rf /home/gitpod/go-packages && \
+    cd home/gitpod/ ; curl -fsSL https://storage.googleapis.com/golang/go$GO_VERSION.linux-amd64.tar.gz | tar -xzv && \
+    go get -u -v \
+        github.com/mdempsky/gocode \
+        github.com/uudashr/gopkgs/cmd/gopkgs \
+        github.com/ramya-rao-a/go-outline \
+        github.com/acroca/go-symbols \
+        golang.org/x/tools/cmd/guru \
+        golang.org/x/tools/cmd/gorename \
+        github.com/fatih/gomodifytags \
+        github.com/haya14busa/goplay/cmd/goplay \
+        github.com/josharian/impl \
+        github.com/tylerb/gotype-live \
+        github.com/rogpeppe/godef \
+        github.com/zmb3/gogetdoc \
+        golang.org/x/tools/cmd/goimports \
+        github.com/sqs/goreturns \
+        winterdrache.de/goformat/goformat \
+        golang.org/x/lint/golint \
+        github.com/cweill/gotests/... \
+        github.com/alecthomas/gometalinter \
+        honnef.co/go/tools/... \
+        github.com/golangci/golangci-lint/cmd/golangci-lint \
+        github.com/mgechev/revive \
+        github.com/sourcegraph/go-langserver \
+        github.com/go-delve/delve/cmd/dlv \
+        github.com/davidrjenni/reftools/cmd/fillstruct \
+        github.com/godoctor/godoctor && \
+    GO111MODULE=on go get -u -v \
+        golang.org/x/tools/gopls@latest && \
+    go get -u -v -d github.com/stamblerre/gocode && \
+    go build -o $GOPATH/bin/gocode-gomod github.com/stamblerre/gocode && \
+    rm -rf $GOPATH/src && \
+    sudo rm -rf $GOPATH/pkg && \
+    rm -rf /home/gitpod/.cache/go
+
+USER gitpod

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,4 @@
+tasks:
+  - command: go version
+image:
+  file: .gitpod.Dockerfile

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# learning-go #
+
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/Eldius/learning-go) 


### PR DESCRIPTION
this commit adds support for Gitpod.io, a free automated
dev environment that makes contributing and generally working on GitHub
projects much easier. It allows anyone to start a ready-to-code dev
environment for any branch, issue and pull request with a single click.